### PR TITLE
코드 스타일 정리와 로직 향상

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ name = "FiletoPic-rust"
 version = "0.1.0"
 dependencies = [
  "image",
- "num-complex 0.2.4",
- "stopwatch",
+ "num-complex",
 ]
 
 [[package]]
@@ -124,12 +123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "gif"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,7 +152,7 @@ dependencies = [
  "gif",
  "jpeg-decoder",
  "num-iter",
- "num-rational 0.2.4",
+ "num-rational",
  "num-traits",
  "png",
  "scoped_threadpool",
@@ -228,42 +221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
-dependencies = [
- "num-bigint",
- "num-complex 0.1.43",
- "num-integer",
- "num-iter",
- "num-rational 0.1.42",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
-dependencies = [
- "num-integer",
- "num-traits",
- "rand",
- "rustc-serialize",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
-dependencies = [
- "num-traits",
- "rustc-serialize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,18 +249,6 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "rustc-serialize",
 ]
 
 [[package]]
@@ -349,34 +294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
 name = "rayon"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,21 +318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-
-[[package]]
 name = "scoped_threadpool"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,15 +330,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "stopwatch"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d04b5ebc78da44d3a456319d8bc2783e7d8cc7ccbb5cb4dc3f54afbd93bf728"
-dependencies = [
- "num",
-]
-
-[[package]]
 name = "tiff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,25 +339,3 @@ dependencies = [
  "lzw",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,3 @@ edition = "2018"
 [dependencies]
 image = "0.23.2"
 num-complex = "0.2.4"
-stopwatch = "0.0.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,9 @@
 extern crate image;
-extern crate stopwatch;
 
 use std::env;
-use std::fs;
-use std::fs::File;
-use std::io;
-use std::io::BufReader;
-use std::io::Read;
-use stopwatch::Stopwatch;
+use std::fs::{self, File};
+use std::io::{self, Read};
+use std::time::Instant;
 
 enum PictureShape {
     Square,
@@ -91,7 +87,7 @@ fn get_divisors(num: u32) -> Vec<Divisor> {
 }
 
 fn run_single(file_path: &str, file_size: u64, size: PictureInfo) {
-    let sw = Stopwatch::start_new();
+    let start_time = Instant::now();
     let mut offset = 0;
     let mut f = File::open(file_path).unwrap();
     let mut file_byte = [0; 3];
@@ -129,5 +125,5 @@ fn run_single(file_path: &str, file_size: u64, size: PictureInfo) {
 
     println!("PNG 압축시작");
     imgbuf.save("output.png").unwrap();
-    println!("작업완료! {}ms", sw.elapsed_ms());
+    println!("작업완료! {:#?}", start_time.elapsed());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,10 +17,7 @@ struct PictureInfo {
     shape: PictureShape,
 }
 
-struct Divisor {
-    A: u32,
-    B: u32,
-}
+type Divisor = (u32, u32);
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -36,35 +33,29 @@ fn main() {
 fn calculate_size(file_size: u64, shape: PictureShape) -> PictureInfo {
     match shape {
         PictureShape::Square => {
-            let mut length = ((file_size / 3) as f64).sqrt();
-
-            if length % 1.0 != 0.0 {
-                length = length.ceil()
-            }
+            let length = ((file_size / 3) as f64).sqrt().ceil() as u32;
 
             PictureInfo {
-                width: length as u32,
-                height: length as u32,
+                width: length,
+                height: length,
                 shape: PictureShape::Square,
             }
         }
         PictureShape::Rectangular => {
-            let mut length = ((file_size / 3) as f64).sqrt();
+            let length = ((file_size / 3) as f64).sqrt() as u32;
 
-            if (length / 3.0) % 1.0 != 0.0 {
-                length = length.ceil()
-            }
-            let divisors = get_divisors(length as u32);
-            for i in 0..divisors.len() {
-                println!("{}: w: {} h:{}", i, divisors[i].A, divisors[i].B);
+            let divisors = get_divisors(length);
+            for (i, divisor) in divisors.iter().enumerate() {
+                println!("{}: w: {} h:{}", i, divisor.0, divisor.1);
             }
 
             let mut input = String::new();
             io::stdin().read_line(&mut input).unwrap();
+            let size = input.trim().parse::<usize>().unwrap();
 
             PictureInfo {
-                width: divisors[input.trim().parse::<usize>().unwrap()].A,
-                height: divisors[input.trim().parse::<usize>().unwrap()].B,
+                width: divisors[size].0,
+                height: divisors[size].1,
                 shape: PictureShape::Rectangular,
             }
         }
@@ -78,9 +69,11 @@ fn calculate_size(file_size: u64, shape: PictureShape) -> PictureInfo {
 
 fn get_divisors(num: u32) -> Vec<Divisor> {
     let mut temp = Vec::new();
-    for i in 1..num {
+    // a * b = num이라면 b * a = num이다.
+    for i in 1..=((num as f32).sqrt() as u32) {
         if num % i == 0 {
-            temp.push(Divisor { A: i, B: num / i });
+            temp.push((i, num / i));
+            temp.push((num / i , i));
         }
     }
     return temp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,18 @@
-extern crate stopwatch;
 extern crate image;
+extern crate stopwatch;
 
+use std::env;
+use std::fs;
+use std::fs::File;
 use std::io;
 use std::io::BufReader;
-use std::fs::File;
 use std::io::Read;
-use std::fs;
-use std::env;
-use stopwatch::{Stopwatch};
+use stopwatch::Stopwatch;
 
-
-enum PictureShape
-{
+enum PictureShape {
     Square,
     Rectangular,
-    Circle
+    Circle,
 }
 
 struct PictureInfo {
@@ -25,17 +23,21 @@ struct PictureInfo {
 
 struct Divisor {
     A: u32,
-    B: u32
+    B: u32,
 }
 
 fn main() {
     let args: Vec<String> = env::args().collect();
     let file_name = &args[1];
     let file_size = fs::metadata(file_name).unwrap().len();
-    run_single(file_name ,file_size,calculate_size(file_size, PictureShape::Square));
+    run_single(
+        file_name,
+        file_size,
+        calculate_size(file_size, PictureShape::Square),
+    );
 }
 
-fn calculate_size(file_size : u64, shape : PictureShape) -> PictureInfo {
+fn calculate_size(file_size: u64, shape: PictureShape) -> PictureInfo {
     match shape {
         PictureShape::Square => {
             let mut length = ((file_size / 3) as f64).sqrt();
@@ -58,80 +60,74 @@ fn calculate_size(file_size : u64, shape : PictureShape) -> PictureInfo {
             }
             let divisors = get_divisors(length as u32);
             for i in 0..divisors.len() {
-                println!("{}: w: {} h:{}",i,divisors[i].A,divisors[i].B);
+                println!("{}: w: {} h:{}", i, divisors[i].A, divisors[i].B);
             }
 
             let mut input = String::new();
             io::stdin().read_line(&mut input).unwrap();
-            
+
             PictureInfo {
                 width: divisors[input.trim().parse::<usize>().unwrap()].A,
                 height: divisors[input.trim().parse::<usize>().unwrap()].B,
                 shape: PictureShape::Rectangular,
             }
         }
-        _ =>  PictureInfo {
+        _ => PictureInfo {
             width: 0,
             height: 0,
             shape: PictureShape::Rectangular,
-        }
+        },
     }
 }
 
-fn get_divisors(num : u32) ->  Vec<Divisor>{
+fn get_divisors(num: u32) -> Vec<Divisor> {
     let mut temp = Vec::new();
     for i in 1..num {
-        if num % i == 0
-        {
-            temp.push(Divisor{A:i, B:num / i});
+        if num % i == 0 {
+            temp.push(Divisor { A: i, B: num / i });
         }
     }
     return temp;
 }
 
-fn run_single(file_path : &str, file_size : u64, size : PictureInfo){
+fn run_single(file_path: &str, file_size: u64, size: PictureInfo) {
     let sw = Stopwatch::start_new();
     let mut offset = 0;
     let mut f = File::open(file_path).unwrap();
     let mut file_byte = [0; 3];
-    let mut imgbuf = image::ImageBuffer::new(size.width, size.height); 
+    let mut imgbuf = image::ImageBuffer::new(size.width, size.height);
 
-'outer: for x in 0..size.width{
-    for y in 0..size.height{
-        match size.shape {
-            PictureShape::Square => {
-                f.read(&mut file_byte[..]).unwrap();
-                if offset >= file_size
-                {          
-                    imgbuf.put_pixel(x, y, image::Rgba([0, 0, 0, 3]));
-                    break;
+    'outer: for x in 0..size.width {
+        for y in 0..size.height {
+            match size.shape {
+                PictureShape::Square => {
+                    f.read(&mut file_byte[..]).unwrap();
+                    if offset >= file_size {
+                        imgbuf.put_pixel(x, y, image::Rgba([0, 0, 0, 3]));
+                        break;
+                    } else if offset + 2 == file_size {
+                        imgbuf.put_pixel(x, y, image::Rgba([file_byte[0], file_byte[1], 0, 2]));
+                        break 'outer;
+                    } else if offset + 1 == file_size {
+                        imgbuf.put_pixel(x, y, image::Rgba([file_byte[0], 0, 0, 1]));
+                    } else if file_size <= offset {
+                        break 'outer;
+                    } else {
+                        imgbuf.put_pixel(
+                            x,
+                            y,
+                            image::Rgba([file_byte[0], file_byte[1], file_byte[2], 255]),
+                        );
+                    }
+                    offset += 3;
                 }
-                else if offset + 2 == file_size
-                {        
-                    imgbuf.put_pixel(x, y, image::Rgba([file_byte[0], file_byte[1], 0, 2]));
-                    break 'outer;
-                }
-                else if offset + 1 == file_size
-                {
-                    imgbuf.put_pixel(x, y, image::Rgba([file_byte[0], 0, 0, 1]));
-                }
-                else if file_size <= offset
-                {
-                    break 'outer;
-                }
-                else
-                { 
-                    imgbuf.put_pixel(x, y, image::Rgba([file_byte[0], file_byte[1], file_byte[2], 255]));
-                }
-                offset += 3;
+
+                _ => {}
             }
-
-            _ => {}
         }
     }
-}
 
-println!("PNG 압축시작");
-imgbuf.save("output.png").unwrap();
-println!("작업완료! {}ms", sw.elapsed_ms());
+    println!("PNG 압축시작");
+    imgbuf.save("output.png").unwrap();
+    println!("작업완료! {}ms", sw.elapsed_ms());
 }


### PR DESCRIPTION
- rustfmt를 사용해 코드 포매팅
- 불필요한 외부 crate 제거
- 전체적인 코드 스타일 개선
- get_divisors 최적화